### PR TITLE
Resolve issues with GPA on Mesa for Apitrace

### DIFF
--- a/Build/Linux/Common.mk
+++ b/Build/Linux/Common.mk
@@ -8,7 +8,7 @@ LINKFLAGS_SO = -shared -Wl,-z,defs $(ADDL_LINKFLAGS)
 PLATFORM_CFLAG =
 PLATFORM_LFLAG =
 TARGET_SUFFIX =
-ADDL_CFLAGS =
+ADDL_CFLAGS = -fno-rtti
 CFLAGS = -std=c++11 $(OPTIMIZE) -fPIC -D_LINUX -Wno-write-strings $(PLATFORM_CFLAG) $(ADDL_CFLAGS)
 # ADDLCFLAGS = -Wall -Wno-unknown-pragmas -Wno-strict-aliasing -Wno-non-virtual-dtor -Werror -msse
 PLATFORM_DIR = x64

--- a/Src/GPUPerfAPI-Common/GPAHWInfo.cpp
+++ b/Src/GPUPerfAPI-Common/GPAHWInfo.cpp
@@ -175,7 +175,7 @@ bool GPA_HWInfo::UpdateRevisionIdBasedOnDeviceIDAndName()
             {
                 string thisMarketingName(it->m_szMarketingName);
 
-                if (thisMarketingName.compare(m_deviceName) == 0)
+                if (m_deviceName.find(thisMarketingName) != std::string::npos)
                 {
                     SetRevisionID(static_cast<gpa_uint32>(it->m_revID));
                     return true;

--- a/Src/GPUPerfAPICounterGenerator/GLEntryPoints.h
+++ b/Src/GPUPerfAPICounterGenerator/GLEntryPoints.h
@@ -29,9 +29,9 @@ extern decltype(wglGetProcAddress)* _wglGetProcAddress; ///< function pointer fo
 #endif
 
 #ifdef _LINUX
-extern decltype(glXGetProcAddressARB)* _glXGetProcAddressARB; ///< function pointer for glXGetProcAddressARB
+extern decltype(glXGetProcAddressARB)* _GPAglXGetProcAddressARB; ///< function pointer for glXGetProcAddressARB
 #define GET_PROC_ADDRESS(f,type,name)\
-    (f) = (type) _glXGetProcAddressARB( (const GLubyte*) name);
+    (f) = (type) _GPAglXGetProcAddressARB( (const GLubyte*) name);
 #endif
 
 #else
@@ -49,9 +49,9 @@ extern decltype(glXGetProcAddressARB)* _glXGetProcAddressARB; ///< function poin
 #include <GLES2/gl2ext.h>
 
 // used for defining the proc addresses which are initialized below
-extern decltype(eglGetProcAddress)* _eglGetProcAddress; ///< function pointer for eglGetProcAddress
+extern decltype(eglGetProcAddress)* _GPAeglGetProcAddress; ///< function pointer for eglGetProcAddress
 #define GET_PROC_ADDRESS(f,type,name)\
-    (f) = (type) _eglGetProcAddress(name);
+    (f) = (type) _GPAeglGetProcAddress(name);
 
 #endif // GLES
 

--- a/Src/GPUPerfAPIGL/GPUPerfAPIGL.cpp
+++ b/Src/GPUPerfAPIGL/GPUPerfAPIGL.cpp
@@ -241,10 +241,11 @@ GPA_Status InitializeGLFunctions()
 #ifdef _WIN32
     HMODULE module = LoadLibraryA("opengl32.dll");
 #else
-    void* module = dlopen("libGL.so", RTLD_LAZY);
+    void* egl_module = dlopen("libEGL.so", RTLD_LAZY);
+    void* gl_module = dlopen("libGL.so", RTLD_LAZY);
 #endif
 
-    if (nullptr == module)
+    if ((nullptr == egl_module) || (nullptr == gl_module))
     {
         return GPA_STATUS_ERROR_NULL_POINTER;
     }
@@ -264,7 +265,7 @@ GPA_Status InitializeGLFunctions()
 #endif
 
 #ifdef _LINUX
-    _GPAglXGetProcAddressARB = reinterpret_cast<decltype(glXGetProcAddressARB)*>(dlsym(module, "glXGetProcAddressARB"));
+    _GPAglXGetProcAddressARB = reinterpret_cast<decltype(glXGetProcAddressARB)*>(dlsym(egl_module, "glXGetProcAddressARB"));
 
     if (nullptr == _GPAglXGetProcAddressARB)
     {
@@ -286,7 +287,7 @@ GPA_Status InitializeGLFunctions()
 #endif
 
 #ifdef _LINUX
-    _GPAeglGetProcAddress = reinterpret_cast<decltype(eglGetProcAddress)*>(dlsym(module, "eglGetProcAddress"));
+    _GPAeglGetProcAddress = reinterpret_cast<decltype(eglGetProcAddress)*>(dlsym(egl_module, "eglGetProcAddress"));
 
     if (nullptr == _GPAeglGetProcAddress)
     {
@@ -303,9 +304,9 @@ GPA_Status InitializeGLFunctions()
     _oglGetIntegerv = reinterpret_cast<decltype(glGetIntegerv)*>(GetProcAddress(module, "glGetIntegerv"));
 #endif
 #ifdef _LINUX
-    _oglFlush = reinterpret_cast<decltype(glFlush)*>(dlsym(module, "glFlush"));
-    _oglGetString = reinterpret_cast<decltype(glGetString)*>(dlsym(module, "glGetString"));
-    _oglGetIntegerv = reinterpret_cast<decltype(glGetIntegerv)*>(dlsym(module, "glGetIntegerv"));
+    _oglFlush = reinterpret_cast<decltype(glFlush)*>(dlsym(gl_module, "glFlush"));
+    _oglGetString = reinterpret_cast<decltype(glGetString)*>(dlsym(gl_module, "glGetString"));
+    _oglGetIntegerv = reinterpret_cast<decltype(glGetIntegerv)*>(dlsym(gl_module, "glGetIntegerv"));
 #endif
 
     if (nullptr == _oglFlush || nullptr == _oglGetString || nullptr == _oglGetIntegerv)

--- a/Src/GPUPerfAPIGL/GPUPerfAPIGL.cpp
+++ b/Src/GPUPerfAPIGL/GPUPerfAPIGL.cpp
@@ -214,11 +214,11 @@ gpa_uint32 GPA_IMP_GetPreferredCheckResultFrequency()
     #endif
 
     #ifdef _LINUX
-        decltype(glXGetProcAddressARB)* _glXGetProcAddressARB = nullptr;
+        decltype(glXGetProcAddressARB)* _GPAglXGetProcAddressARB = nullptr;
     #endif
 
 #else
-    decltype(eglGetProcAddress)* _eglGetProcAddress = nullptr;
+    decltype(eglGetProcAddress)* _GPAeglGetProcAddress = nullptr;
 #endif
 
 /// Checks the OpenGL extensions and initializes the various function pointers.  The extensions queried are:
@@ -264,9 +264,9 @@ GPA_Status InitializeGLFunctions()
 #endif
 
 #ifdef _LINUX
-    _glXGetProcAddressARB = reinterpret_cast<decltype(glXGetProcAddressARB)*>(dlsym(module, "glXGetProcAddressARB"));
+    _GPAglXGetProcAddressARB = reinterpret_cast<decltype(glXGetProcAddressARB)*>(dlsym(module, "glXGetProcAddressARB"));
 
-    if (nullptr == _glXGetProcAddressARB)
+    if (nullptr == _GPAglXGetProcAddressARB)
     {
         return GPA_STATUS_ERROR_NULL_POINTER;
     }
@@ -276,9 +276,9 @@ GPA_Status InitializeGLFunctions()
 #else // GLES
 
 #ifdef _WIN32
-    _eglGetProcAddress = reinterpret_cast<decltype(eglGetProcAddress)*>(GetProcAddress(module, "eglGetProcAddress"));
+    _GPAeglGetProcAddress = reinterpret_cast<decltype(eglGetProcAddress)*>(GetProcAddress(module, "eglGetProcAddress"));
 
-    if (nullptr == _eglGetProcAddress)
+    if (nullptr == _GPAeglGetProcAddress)
     {
         return GPA_STATUS_ERROR_NULL_POINTER;
     }
@@ -286,9 +286,9 @@ GPA_Status InitializeGLFunctions()
 #endif
 
 #ifdef _LINUX
-    _eglGetProcAddress = reinterpret_cast<decltype(eglGetProcAddress)*>(dlsym(module, "eglGetProcAddress"));
+    _GPAeglGetProcAddress = reinterpret_cast<decltype(eglGetProcAddress)*>(dlsym(module, "eglGetProcAddress"));
 
-    if (nullptr == _eglGetProcAddress)
+    if (nullptr == _GPAeglGetProcAddress)
     {
         return GPA_STATUS_ERROR_NULL_POINTER;
     }

--- a/Src/GPUPerfAPIGL/GPUPerfAPIGL.cpp
+++ b/Src/GPUPerfAPIGL/GPUPerfAPIGL.cpp
@@ -1033,7 +1033,7 @@ GPA_Status GPA_IMP_OpenContext(void* pContext)
                     // There will be no catastrophic errors if the GPA expects less counters than GL exposes, but we may not have the right counters... and may be reporting bad results.
                     // There could be major issues if the GPA expects more counters than GL exposes, because we may try to enable a counter that doesn't exist,
                     // in which case we hope the driver will return a 0 result and not write unexpected values into the register.
-                    assert(pHardwareCounters->m_pGroups[g].m_numCounters == (unsigned int)nCounters);
+                    // assert(pHardwareCounters->m_pGroups[g].m_numCounters >= (unsigned int)nCounters);
 
                     if (pHardwareCounters->m_pGroups[g].m_numCounters != (unsigned int)nCounters)
                     {

--- a/Src/GPUPerfAPIGL/GPUPerfAPIGL.cpp
+++ b/Src/GPUPerfAPIGL/GPUPerfAPIGL.cpp
@@ -500,14 +500,14 @@ GPA_Status InitializeGLFunctions()
     GET_PROC_ADDRESS(_oglDeleteQueries,            PFNGLDELETEQUERIESPROC,          "glDeleteQueries");
     GET_PROC_ADDRESS(_oglQueryCounter,             PFNGLQUERYCOUNTERPROC,           "glQueryCounter");
 #else
-    GET_PROC_ADDRESS(_oglBeginQuery,               PFNGLBEGINQUERYPROC,             "glBeginQueryEXT");
-    GET_PROC_ADDRESS(_oglEndQuery,                 PFNGLENDQUERYPROC,               "glEndQueryEXT");
-    GET_PROC_ADDRESS(_oglGetQueryiv,               PFNGLGETQUERYIVPROC,             "glGetQueryivEXT");
+    GET_PROC_ADDRESS(_oglBeginQuery,               PFNGLBEGINQUERYPROC,             "glBeginQuery");
+    GET_PROC_ADDRESS(_oglEndQuery,                 PFNGLENDQUERYPROC,               "glEndQuery");
+    GET_PROC_ADDRESS(_oglGetQueryiv,               PFNGLGETQUERYIVPROC,             "glGetQueryiv");
     GET_PROC_ADDRESS(_oglGetQueryObjectui64vEXT,   PFNGLGETQUERYOBJECTUI64VEXTPROC, "glGetQueryObjectui64vEXT");
-    GET_PROC_ADDRESS(_oglGetQueryObjectiv,         PFNGLGETQUERYOBJECTIVPROC,       "glGetQueryObjectivEXT");
-    GET_PROC_ADDRESS(_oglGenQueries,               PFNGLGENQUERIESPROC,             "glGenQueriesEXT");
-    GET_PROC_ADDRESS(_oglDeleteQueries,            PFNGLDELETEQUERIESPROC,          "glDeleteQueriesEXT");
-    GET_PROC_ADDRESS(_oglQueryCounter,             PFNGLQUERYCOUNTEREXTPROC,        "glQueryCounterEXT");
+    GET_PROC_ADDRESS(_oglGetQueryObjectiv,         PFNGLGETQUERYOBJECTIVPROC,       "glGetQueryObjectiv");
+    GET_PROC_ADDRESS(_oglGenQueries,               PFNGLGENQUERIESPROC,             "glGenQueries");
+    GET_PROC_ADDRESS(_oglDeleteQueries,            PFNGLDELETEQUERIESPROC,          "glDeleteQueries");
+    GET_PROC_ADDRESS(_oglQueryCounter,             PFNGLQUERYCOUNTERPROC,        "glQueryCounter");
 
 #ifndef GL_TIMESTAMP
 #define GL_TIMESTAMP GL_TIMESTAMP_EXT

--- a/Src/GPUPerfAPIGL/makefile
+++ b/Src/GPUPerfAPIGL/makefile
@@ -4,6 +4,7 @@ DEPTH = ../..
 include $(DEPTH)/Build/Linux/Common.mk
 
 TARGETSO = libGPUPerfAPIGL$(TARGET_SUFFIX).so
+TARGETLIB = libGPUPerfAPIGL$(TARGET_SUFFIX).a
 ADDL_DEFINES = -DGLX_GLXEXT_PROTOTYPES
 
 INCLUDES =	-I. \
@@ -29,6 +30,8 @@ SO_OBJS	= \
 	./$(OBJ_DIR)/ASICInfo.o \
 	./$(OBJ_DIR)/GPUPerfAPIGL.o \
 	./$(OBJ_DIR)/GLPerfMonitorCache.o
+
+LIB_OBJS = $(SO_OBJS)
 
 include $(DEPTH)/Build/Linux/CommonTargets.mk
 

--- a/Src/GPUPerfAPIGLES/makefile
+++ b/Src/GPUPerfAPIGLES/makefile
@@ -3,7 +3,9 @@
 DEPTH = ../..
 include $(DEPTH)/Build/Linux/Common.mk
 
-TARGETSO = libGPUPerfAPIGLES$(TARGET_SUFFIX).so
+# TARGETSO = libGPUPerfAPIGLES$(TARGET_SUFFIX).so
+TARGETLIB = libGPUPerfAPIGLES$(TARGET_SUFFIX).a
+
 ADDL_DEFINES = -DGLX_GLXEXT_PROTOTYPES -DGLES
 
 INCLUDES =	-I. \
@@ -29,6 +31,8 @@ SO_OBJS = \
 	./$(OBJ_DIR)/ASICInfo.o \
 	./$(OBJ_DIR)/GPUPerfAPIGL.o \
 	./$(OBJ_DIR)/GLPerfMonitorCache.o
+
+LIB_OBJS = $(SO_OBJS)
 
 include $(DEPTH)/Build/Linux/CommonTargets.mk
 


### PR DESCRIPTION
The rtti & clashes commits only exist because I am linking statically.  I can understand if you don't want to take those patches, but it is easier for me to link statically.

There are many things that I didn't test/fix for the build, like the linking to a precompiled gtest lib.  That's simply not the way you want to manage external dependencies on linux.

Other cross-platform projects that I have worked on use CMake or Meson for cross-platform build support.  Typically, they realize right away that maintaining the build in CMake is superior to checking in Visual Studio projects to perforce.